### PR TITLE
Refocus DiagIA on AI audit maturity assessment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+node_modules
+npm-debug.log
+Dockerfile
+README.md
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+COPY index.html app.js audit-core.js roi-core.js styles.css server.js ./
+
+ENV NODE_ENV=production
+ENV PORT=8080
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:8080/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # DiagIA — Audit IA Web
 
-Application web statique pour conduire un **audit de maturité IA générative** (TPE, PME, établissements scolaires).
+Application web pour conduire un **audit de maturité IA générative** (TPE, PME, établissements scolaires).
 
-## Ce que fait cette version
+## Fonctionnalités
 
-- Questionnaire guidé orienté **audit IA** (gouvernance, conformité, usages, compétences, pilotage).
-- Score de maturité global **/100** et score par pilier **/20**.
-- Détection des risques clés (gouvernance faible, conformité, shadow AI).
-- Plan d’action automatique **30/60/90 jours**.
+- Questionnaire guidé orienté audit IA.
+- Score global **/100** + score par pilier **/20**.
+- Détection des risques (gouvernance, conformité, shadow AI).
+- Plan d’action **30/60/90 jours**.
 - Export des résultats en **JSON/CSV**.
 
-## Lancer en local
+## Lancement local (dev)
 
 ```bash
 python3 -m http.server 8000
@@ -18,17 +18,43 @@ python3 -m http.server 8000
 
 Puis ouvrir `http://localhost:8000`.
 
+## Mise en production
+
+### Option 1 — Serveur Node natif
+
+```bash
+npm run start
+```
+
+Variables:
+- `PORT` (défaut `8080`)
+- `HOST` (défaut `0.0.0.0`)
+
+Endpoints:
+- `GET /` application
+- `GET /healthz` healthcheck
+
+### Option 2 — Docker
+
+```bash
+docker build -t diagia-audit:latest .
+docker run -d --name diagia-audit -p 8080:8080 diagia-audit:latest
+```
+
+Puis vérifier:
+
+```bash
+curl http://localhost:8080/healthz
+```
+
 ## Tests
 
 ```bash
-node --check app.js
-node --check audit-core.js
-node --test tests/audit-core.test.js
+npm run check
+npm run test
 ```
 
-## Démo rapide
-
-Exemple de réponses (maturité faible pour voir les recommandations):
+## Démo rapide (audit faible maturité)
 
 1. `MonOrg, PME`
 2. `20`
@@ -43,9 +69,3 @@ Exemple de réponses (maturité faible pour voir les recommandations):
 11. `non`
 12. `non`
 13. `non`
-
-À la fin, vérifier:
-- score global,
-- 5 scores piliers,
-- plan d'action,
-- export JSON/CSV.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,51 @@
-- 👋 Hi, I’m @Camusseb
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
+# DiagIA — Audit IA Web
 
-<!---
-Camusseb/Camusseb is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Application web statique pour conduire un **audit de maturité IA générative** (TPE, PME, établissements scolaires).
+
+## Ce que fait cette version
+
+- Questionnaire guidé orienté **audit IA** (gouvernance, conformité, usages, compétences, pilotage).
+- Score de maturité global **/100** et score par pilier **/20**.
+- Détection des risques clés (gouvernance faible, conformité, shadow AI).
+- Plan d’action automatique **30/60/90 jours**.
+- Export des résultats en **JSON/CSV**.
+
+## Lancer en local
+
+```bash
+python3 -m http.server 8000
+```
+
+Puis ouvrir `http://localhost:8000`.
+
+## Tests
+
+```bash
+node --check app.js
+node --check audit-core.js
+node --test tests/audit-core.test.js
+```
+
+## Démo rapide
+
+Exemple de réponses (maturité faible pour voir les recommandations):
+
+1. `MonOrg, PME`
+2. `20`
+3. `Standardiser les process`
+4. `non`
+5. `non`
+6. `non`
+7. `non`
+8. `oui`
+9. `1`
+10. `non`
+11. `non`
+12. `non`
+13. `non`
+
+À la fin, vérifier:
+- score global,
+- 5 scores piliers,
+- plan d'action,
+- export JSON/CSV.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Endpoints:
 - `GET /` application
 - `GET /healthz` healthcheck
 
+Sécurité HTTP intégrée:
+- `Content-Security-Policy`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+
 ### Option 2 — Docker
 
 ```bash
@@ -53,6 +58,8 @@ curl http://localhost:8080/healthz
 npm run check
 npm run test
 ```
+
+Le script `npm run test` inclut les tests de logique métier et les tests serveur (healthcheck, méthodes HTTP, anti-traversal).
 
 ## Démo rapide (audit faible maturité)
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,172 @@
+const auditApi = window.DiagIAAudit;
+
+const messagesEl = document.getElementById('messages');
+const form = document.getElementById('answerForm');
+const input = document.getElementById('answerInput');
+const reportPanel = document.getElementById('reportPanel');
+const riskBadges = document.getElementById('riskBadges');
+const scoreCard = document.getElementById('scoreCard');
+const pillarCards = document.getElementById('pillarCards');
+const actionPlanEl = document.getElementById('actionPlan');
+const downloadJsonBtn = document.getElementById('downloadJson');
+const downloadCsvBtn = document.getElementById('downloadCsv');
+
+const session = { risques: [] };
+
+const steps = [
+  {
+    key: 'intro',
+    question:
+      '🤖 DiagIA activé — Mode Agent | SebGPT\n\nPlan audit IA:\n1) Cadrage organisation\n2) Gouvernance & conformité\n3) Usages & compétences\n4) Pilotage\n5) Rapport de maturité\n\nQuel est le nom de votre organisation et votre secteur ? (format: Organisation, Secteur)',
+    onAnswer: (answer) => {
+      const [org, ...rest] = answer.split(',');
+      session.organisation = org?.trim() || answer.trim();
+      session.secteur = rest.join(',').trim() || 'non précisé';
+    },
+  },
+  { key: 'size', question: 'Combien de personnes composent vos équipes ?', field: 'tailleEquipe' },
+  { key: 'defi', question: 'Quel est votre principal défi opérationnel ?', field: 'defi' },
+  {
+    key: 'charte',
+    question: 'Avez-vous une charte IA interne ? (oui/non)',
+    field: 'charteIA',
+    onAnswer: (answer) => {
+      if (/non/i.test(answer)) session.risques.push('Gouvernance faible');
+    },
+  },
+  { key: 'referent', question: 'Avez-vous un référent IA identifié ? (oui/non)', field: 'referentIA' },
+  {
+    key: 'rgpd',
+    question: 'Disposez-vous de règles RGPD spécifiques pour l’usage IA ? (oui/non)',
+    field: 'cadreRGPD',
+    onAnswer: (answer) => {
+      if (/non/i.test(answer)) session.risques.push('Risque conformité RGPD');
+    },
+  },
+  { key: 'juridique', question: 'Les contenus IA sensibles sont-ils validés juridiquement ? (oui/non)', field: 'validationJuridique' },
+  {
+    key: 'shadow',
+    question: 'Des comptes IA personnels sont-ils utilisés pour des tâches pro ? (oui/non)',
+    field: 'shadowPersonalAccounts',
+    onAnswer: (answer) => {
+      if (/oui/i.test(answer)) session.risques.push('Shadow AI actif');
+    },
+  },
+  {
+    key: 'casusage',
+    question: 'Combien de cas d’usage IA sont réellement actifs aujourd’hui ? (nombre)',
+    onAnswer: (answer) => {
+      const v = Number.parseInt(answer, 10);
+      session.nbCasUsage = Number.isFinite(v) ? v : 0;
+    },
+  },
+  { key: 'formation', question: 'Avez-vous formé les équipes à l’IA générative ? (oui/non)', field: 'formationIA' },
+  { key: 'prompts', question: 'Disposez-vous d’un framework de prompts (templates) ? (oui/non)', field: 'promptFramework' },
+  { key: 'kpi', question: 'Suivez-vous des KPI IA (temps gagné, qualité, coûts) ? (oui/non)', field: 'kpiIA' },
+  { key: 'roadmap', question: 'Avez-vous une roadmap IA 12 mois ? (oui/non)', field: 'roadmapIA', postMessage: () => renderReport() },
+];
+
+let currentStep = 0;
+
+function addMessage(text, role = 'agent') {
+  const node = document.createElement('div');
+  node.className = `msg ${role}`;
+  node.textContent = text;
+  messagesEl.appendChild(node);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function askCurrent() {
+  if (currentStep < steps.length) {
+    addMessage(steps[currentStep].question, 'agent');
+  } else {
+    form.classList.add('hidden');
+  }
+}
+
+function renderRisks() {
+  const tags = session.risques.length
+    ? session.risques.map((r) => `<span class="risk critical">${r}</span>`)
+    : ['<span class="risk info">Aucun risque critique détecté</span>'];
+  riskBadges.innerHTML = tags.join('');
+}
+
+function renderScore(score) {
+  scoreCard.innerHTML = `
+    <article class="kpi">
+      <p class="label">Score global de maturité</p>
+      <p class="value">${score.total}/100</p>
+      <p class="label">${score.level.label}</p>
+    </article>
+  `;
+
+  const labels = {
+    gouvernance: 'Gouvernance',
+    conformite: 'Conformité',
+    usages: 'Usages',
+    competences: 'Compétences',
+    pilotage: 'Pilotage',
+  };
+
+  pillarCards.innerHTML = Object.entries(score.pillars)
+    .map(([key, value]) => `<article class="kpi"><p class="label">${labels[key]}</p><p class="value">${value}/20</p></article>`)
+    .join('');
+}
+
+function renderActions(actions) {
+  actionPlanEl.innerHTML = actions.map((a) => `<li>${a}</li>`).join('');
+}
+
+function renderReport() {
+  const score = auditApi.computeAuditScore(session);
+  const actions = auditApi.buildActionPlan(score);
+  session.audit = score;
+  session.plan = actions;
+  renderRisks();
+  renderScore(score);
+  renderActions(actions);
+  reportPanel.classList.remove('hidden');
+  addMessage('Audit terminé ✅ Rapport de maturité généré.', 'agent');
+}
+
+function toCsvRows(data) {
+  return Object.entries(data)
+    .map(([k, v]) => `${JSON.stringify(k)},${JSON.stringify(typeof v === 'object' ? JSON.stringify(v) : String(v))}`)
+    .join('\n');
+}
+
+function downloadFile(name, content, mimeType) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+downloadJsonBtn.addEventListener('click', () => {
+  downloadFile('audit-ia-report.json', JSON.stringify({ session, generatedAt: new Date().toISOString() }, null, 2), 'application/json');
+});
+
+downloadCsvBtn.addEventListener('click', () => {
+  downloadFile('audit-ia-report.csv', toCsvRows({ ...session, generatedAt: new Date().toISOString() }), 'text/csv;charset=utf-8');
+});
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const answer = input.value.trim();
+  if (!answer) return;
+
+  addMessage(answer, 'user');
+  const step = steps[currentStep];
+  if (step.field) session[step.field] = answer;
+  if (typeof step.onAnswer === 'function') step.onAnswer(answer);
+  if (typeof step.postMessage === 'function') step.postMessage();
+
+  currentStep += 1;
+  input.value = '';
+  askCurrent();
+});
+
+askCurrent();

--- a/audit-core.js
+++ b/audit-core.js
@@ -1,0 +1,58 @@
+(function (globalScope) {
+  const maturityLevels = [
+    { max: 24, label: 'Niveau 1 — Initial', color: 'critical' },
+    { max: 49, label: 'Niveau 2 — Opportuniste', color: 'warning' },
+    { max: 74, label: 'Niveau 3 — Structuré', color: 'info' },
+    { max: 100, label: 'Niveau 4 — Piloté', color: 'success' },
+  ];
+
+  function yesNoScore(value, yes = 20, no = 0) {
+    return /oui|yes|ok/i.test(String(value || '')) ? yes : no;
+  }
+
+  function clamp(v, min, max) {
+    return Math.min(max, Math.max(min, v));
+  }
+
+  function computeAuditScore(session) {
+    const governance = clamp(yesNoScore(session.charteIA, 20, 2) + yesNoScore(session.referentIA, 20, 0), 0, 20);
+    const compliance = clamp(yesNoScore(session.cadreRGPD, 20, 3) + yesNoScore(session.validationJuridique, 20, 0), 0, 20);
+    const usages = clamp((Number(session.nbCasUsage || 0) >= 3 ? 12 : Number(session.nbCasUsage || 0) * 4) + yesNoScore(session.shadowPersonalAccounts, 2, 8), 0, 20);
+    const competences = clamp(yesNoScore(session.formationIA, 14, 2) + yesNoScore(session.promptFramework, 6, 0), 0, 20);
+    const pilotage = clamp(yesNoScore(session.kpiIA, 14, 2) + yesNoScore(session.roadmapIA, 6, 0), 0, 20);
+
+    const total = governance + compliance + usages + competences + pilotage;
+    const level = maturityLevels.find((entry) => total <= entry.max) || maturityLevels[maturityLevels.length - 1];
+
+    return {
+      total,
+      level,
+      pillars: {
+        gouvernance: governance,
+        conformite: compliance,
+        usages,
+        competences,
+        pilotage,
+      },
+    };
+  }
+
+  function buildActionPlan(score) {
+    const plan = [];
+    if (score.pillars.gouvernance < 12) plan.push('J+30: nommer un référent IA et publier une charte interne de 1 page.');
+    if (score.pillars.conformite < 12) plan.push('J+30: cadrer les données interdites et la checklist RGPD pour les prompts.');
+    if (score.pillars.competences < 12) plan.push('J+60: lancer un atelier formation IA + guide de prompts par métier.');
+    if (score.pillars.usages < 12) plan.push('J+60: sélectionner 3 cas d’usage prioritaires et mesurer le gain temps.');
+    if (score.pillars.pilotage < 12) plan.push('J+90: suivre 3 KPI IA mensuels dans un comité de pilotage.');
+    if (plan.length === 0) plan.push('Continuer l’industrialisation: généraliser les standards IA à tous les services.');
+    return plan;
+  }
+
+  const api = { computeAuditScore, buildActionPlan };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    globalScope.DiagIAAudit = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DiagIA — Audit IA</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="hero">
+        <p class="badge">DiagIA • Audit IA</p>
+        <h1>Audit de maturité IA générative</h1>
+        <p class="subtitle">Évaluez votre niveau sur 5 piliers et obtenez un plan d'action 30/60/90 jours.</p>
+      </header>
+
+      <section class="panel" aria-live="polite">
+        <div id="messages" class="messages"></div>
+        <form id="answerForm" class="answer-form">
+          <label for="answerInput">Votre réponse</label>
+          <div class="row">
+            <input id="answerInput" type="text" autocomplete="off" required />
+            <button type="submit">Envoyer</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="panel hidden" id="reportPanel">
+        <h2>Rapport d'audit IA</h2>
+        <div id="riskBadges" class="risk-badges"></div>
+        <div id="scoreCard" class="score-card"></div>
+        <div id="pillarCards" class="roi-results"></div>
+        <h3>Priorités recommandées</h3>
+        <ul id="actionPlan" class="action-plan"></ul>
+        <div class="actions">
+          <button id="downloadJson" type="button">Exporter JSON</button>
+          <button id="downloadCsv" type="button">Exporter CSV</button>
+        </div>
+      </section>
+    </main>
+
+    <script src="audit-core.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --test tests/audit-core.test.js && node --test tests/roi-core.test.js",
+    "test": "node --test tests/audit-core.test.js && node --test tests/roi-core.test.js && node --test tests/server.test.js",
     "check": "node --check app.js && node --check audit-core.js && node --check roi-core.js && node --check server.js"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "diagia-audit-web",
+  "version": "1.0.0",
+  "private": true,
+  "description": "DiagIA audit maturity web app - production server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test tests/audit-core.test.js && node --test tests/roi-core.test.js",
+    "check": "node --check app.js && node --check audit-core.js && node --check roi-core.js && node --check server.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/roi-core.js
+++ b/roi-core.js
@@ -1,0 +1,84 @@
+(function (globalScope) {
+  const defaultHourlyCostBySector = {
+    education: 26,
+    industrie: 31,
+    pme: 30,
+    default: 28,
+  };
+
+  function normalizeSector(sectorRaw) {
+    const value = String(sectorRaw || '').toLowerCase();
+    if (value.includes('école') || value.includes('ecole') || value.includes('education')) return 'education';
+    if (value.includes('industrie')) return 'industrie';
+    if (value.includes('pme') || value.includes('tpe')) return 'pme';
+    return 'default';
+  }
+
+  function parseFrequency(raw) {
+    const normalized = String(raw || '')
+      .toLowerCase()
+      .replace(',', '.')
+      .replace(/\s+/g, '');
+
+    const value = Number.parseFloat(normalized);
+    if (!Number.isFinite(value)) return 0;
+    if (normalized.includes('/semaine') || normalized.includes('semaine')) return value * 4.33;
+    return value;
+  }
+
+  function resolveHourlyCost(rawInput, sectorRaw) {
+    const parsed = Number.parseFloat(String(rawInput || '').trim().replace(',', '.'));
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return { cost: parsed, fallbackUsed: false };
+    }
+
+    const sectorKey = normalizeSector(sectorRaw);
+    return {
+      cost: defaultHourlyCostBySector[sectorKey],
+      fallbackUsed: true,
+    };
+  }
+
+  function computeRoi({ tempsH = 0, volumeMensuel = 0, coutHoraire = 0 }) {
+    const T = Number(tempsH || 0);
+    const V = Number(volumeMensuel || 0);
+    const C = Number(coutHoraire || 0);
+
+    const tempsIA = T * 0.2;
+    const gainHDoc = T - tempsIA;
+    const gainHMois = gainHDoc * V;
+    const gainHAn = gainHMois * 12;
+    const gainEurosAn = gainHAn * C;
+    const coutFormation = 1500;
+    const roiNet = gainEurosAn - coutFormation;
+    const payback = gainEurosAn > 0 ? coutFormation / (gainEurosAn / 12) : 0;
+
+    return {
+      T,
+      V,
+      C,
+      tempsIA,
+      gainHDoc,
+      gainHMois,
+      gainHAn,
+      gainEurosAn,
+      coutFormation,
+      roiNet,
+      payback,
+    };
+  }
+
+  const api = {
+    defaultHourlyCostBySector,
+    normalizeSector,
+    parseFrequency,
+    resolveHourlyCost,
+    computeRoi,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    globalScope.DiagIARoi = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/server.js
+++ b/server.js
@@ -2,9 +2,6 @@ const http = require('node:http');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const PORT = Number(process.env.PORT || 8080);
-const HOST = process.env.HOST || '0.0.0.0';
-
 const MIME_TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.js': 'application/javascript; charset=utf-8',
@@ -19,7 +16,7 @@ const MIME_TYPES = {
 const CACHEABLE_EXTENSIONS = new Set(['.js', '.css', '.png', '.svg', '.ico']);
 
 function safePathFromUrl(urlPath) {
-  const cleanPath = decodeURIComponent(urlPath.split('?')[0]);
+  const cleanPath = decodeURIComponent(String(urlPath || '/').split('?')[0]);
   if (cleanPath === '/' || cleanPath === '') return path.join(process.cwd(), 'index.html');
   const resolved = path.resolve(process.cwd(), `.${cleanPath}`);
   if (!resolved.startsWith(process.cwd())) return null;
@@ -31,46 +28,75 @@ function send(res, status, headers, body) {
   res.end(body);
 }
 
-const server = http.createServer((req, res) => {
-  if (req.url === '/healthz') {
-    return send(res, 200, { 'content-type': 'application/json; charset=utf-8' }, JSON.stringify({ status: 'ok' }));
-  }
+function buildHeaders(ext) {
+  return {
+    'content-type': MIME_TYPES[ext] || 'application/octet-stream',
+    'x-content-type-options': 'nosniff',
+    'x-frame-options': 'DENY',
+    'referrer-policy': 'no-referrer',
+    'content-security-policy': "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'",
+    'cache-control': CACHEABLE_EXTENSIONS.has(ext)
+      ? 'public, max-age=3600, immutable'
+      : 'no-store',
+  };
+}
 
-  const filePath = safePathFromUrl(req.url || '/');
-  if (!filePath) {
-    return send(res, 400, { 'content-type': 'text/plain; charset=utf-8' }, 'Bad request');
-  }
+function createServer() {
+  return http.createServer((req, res) => {
+    const method = req.method || 'GET';
 
-  fs.stat(filePath, (err, stats) => {
-    if (err || !stats.isFile()) {
-      return send(res, 404, { 'content-type': 'text/plain; charset=utf-8' }, 'Not found');
+    if (!['GET', 'HEAD'].includes(method)) {
+      return send(res, 405, { 'content-type': 'text/plain; charset=utf-8' }, 'Method not allowed');
     }
 
-    const ext = path.extname(filePath).toLowerCase();
-    const headers = {
-      'content-type': MIME_TYPES[ext] || 'application/octet-stream',
-      'x-content-type-options': 'nosniff',
-      'x-frame-options': 'DENY',
-      'referrer-policy': 'no-referrer',
-      'cache-control': CACHEABLE_EXTENSIONS.has(ext)
-        ? 'public, max-age=3600, immutable'
-        : 'no-store',
-    };
+    if (req.url === '/healthz') {
+      return send(
+        res,
+        200,
+        { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+        JSON.stringify({ status: 'ok' })
+      );
+    }
 
-    const stream = fs.createReadStream(filePath);
-    res.writeHead(200, headers);
-    stream.pipe(res);
-    stream.on('error', () => {
-      if (!res.headersSent) {
-        send(res, 500, { 'content-type': 'text/plain; charset=utf-8' }, 'Server error');
-      } else {
-        res.destroy();
+    const filePath = safePathFromUrl(req.url || '/');
+    if (!filePath) {
+      return send(res, 400, { 'content-type': 'text/plain; charset=utf-8' }, 'Bad request');
+    }
+
+    fs.stat(filePath, (err, stats) => {
+      if (err || !stats.isFile()) {
+        return send(res, 404, { 'content-type': 'text/plain; charset=utf-8' }, 'Not found');
       }
+
+      const ext = path.extname(filePath).toLowerCase();
+      const headers = buildHeaders(ext);
+
+      if (method === 'HEAD') {
+        return send(res, 200, headers, '');
+      }
+
+      const stream = fs.createReadStream(filePath);
+      res.writeHead(200, headers);
+      stream.pipe(res);
+      stream.on('error', () => {
+        if (!res.headersSent) {
+          send(res, 500, { 'content-type': 'text/plain; charset=utf-8' }, 'Server error');
+        } else {
+          res.destroy();
+        }
+      });
     });
   });
-});
+}
 
-server.listen(PORT, HOST, () => {
-  // eslint-disable-next-line no-console
-  console.log(`DiagIA server listening on http://${HOST}:${PORT}`);
-});
+if (require.main === module) {
+  const PORT = Number(process.env.PORT || 8080);
+  const HOST = process.env.HOST || '0.0.0.0';
+  const server = createServer();
+  server.listen(PORT, HOST, () => {
+    // eslint-disable-next-line no-console
+    console.log(`DiagIA server listening on http://${HOST}:${PORT}`);
+  });
+}
+
+module.exports = { createServer, safePathFromUrl, buildHeaders };

--- a/server.js
+++ b/server.js
@@ -1,0 +1,76 @@
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PORT = Number(process.env.PORT || 8080);
+const HOST = process.env.HOST || '0.0.0.0';
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+};
+
+const CACHEABLE_EXTENSIONS = new Set(['.js', '.css', '.png', '.svg', '.ico']);
+
+function safePathFromUrl(urlPath) {
+  const cleanPath = decodeURIComponent(urlPath.split('?')[0]);
+  if (cleanPath === '/' || cleanPath === '') return path.join(process.cwd(), 'index.html');
+  const resolved = path.resolve(process.cwd(), `.${cleanPath}`);
+  if (!resolved.startsWith(process.cwd())) return null;
+  return resolved;
+}
+
+function send(res, status, headers, body) {
+  res.writeHead(status, headers);
+  res.end(body);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/healthz') {
+    return send(res, 200, { 'content-type': 'application/json; charset=utf-8' }, JSON.stringify({ status: 'ok' }));
+  }
+
+  const filePath = safePathFromUrl(req.url || '/');
+  if (!filePath) {
+    return send(res, 400, { 'content-type': 'text/plain; charset=utf-8' }, 'Bad request');
+  }
+
+  fs.stat(filePath, (err, stats) => {
+    if (err || !stats.isFile()) {
+      return send(res, 404, { 'content-type': 'text/plain; charset=utf-8' }, 'Not found');
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const headers = {
+      'content-type': MIME_TYPES[ext] || 'application/octet-stream',
+      'x-content-type-options': 'nosniff',
+      'x-frame-options': 'DENY',
+      'referrer-policy': 'no-referrer',
+      'cache-control': CACHEABLE_EXTENSIONS.has(ext)
+        ? 'public, max-age=3600, immutable'
+        : 'no-store',
+    };
+
+    const stream = fs.createReadStream(filePath);
+    res.writeHead(200, headers);
+    stream.pipe(res);
+    stream.on('error', () => {
+      if (!res.headersSent) {
+        send(res, 500, { 'content-type': 'text/plain; charset=utf-8' }, 'Server error');
+      } else {
+        res.destroy();
+      }
+    });
+  });
+});
+
+server.listen(PORT, HOST, () => {
+  // eslint-disable-next-line no-console
+  console.log(`DiagIA server listening on http://${HOST}:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,210 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  --bg: #0f172a;
+  --text: #f9fafb;
+  --muted: #9ca3af;
+  --accent: #22c55e;
+  --agent: #0ea5e9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1d4ed8 0%, var(--bg) 45%);
+  color: var(--text);
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+.hero {
+  margin-bottom: 1rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.65rem;
+  background: rgba(34, 197, 94, 0.2);
+  border: 1px solid rgba(34, 197, 94, 0.5);
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.subtitle {
+  color: var(--muted);
+}
+
+.panel {
+  background: rgba(17, 24, 39, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.messages {
+  min-height: 360px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.msg {
+  padding: 0.75rem;
+  border-radius: 10px;
+  margin-bottom: 0.65rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.msg.agent {
+  background: rgba(14, 165, 233, 0.18);
+  border: 1px solid rgba(14, 165, 233, 0.6);
+}
+
+.msg.user {
+  background: rgba(55, 65, 81, 0.7);
+  border: 1px solid rgba(156, 163, 175, 0.4);
+}
+
+.answer-form {
+  border-top: 1px solid rgba(156, 163, 175, 0.25);
+  padding-top: 1rem;
+}
+
+.answer-form label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+input {
+  flex: 1;
+  border-radius: 8px;
+  border: 1px solid rgba(156, 163, 175, 0.5);
+  background: #0b1220;
+  color: var(--text);
+  padding: 0.7rem;
+}
+
+button {
+  background: var(--accent);
+  color: #052e16;
+  border: none;
+  border-radius: 8px;
+  padding: 0.7rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.hidden {
+  display: none;
+}
+
+.risk-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.7rem;
+}
+
+.risk {
+  font-size: 0.85rem;
+  border: 1px solid;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+}
+
+.risk.critical {
+  border-color: rgba(239, 68, 68, 0.9);
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.risk.warning {
+  border-color: rgba(234, 179, 8, 0.9);
+  background: rgba(234, 179, 8, 0.2);
+}
+
+.risk.info {
+  border-color: rgba(56, 189, 248, 0.9);
+  background: rgba(56, 189, 248, 0.2);
+}
+
+.roi-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.kpi {
+  background: rgba(31, 41, 55, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 10px;
+  padding: 0.7rem;
+}
+
+.kpi p {
+  margin: 0;
+}
+
+.kpi .label {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.kpi .value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-top: 0.25rem;
+}
+
+#roiChart {
+  width: 100%;
+  background: rgba(3, 7, 18, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 10px;
+}
+
+.actions {
+  margin-top: 0.9rem;
+  display: flex;
+  gap: 0.6rem;
+}
+
+
+.score-card {
+  margin-bottom: 0.75rem;
+}
+
+.action-plan {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--text);
+}
+
+.action-plan li {
+  margin-bottom: 0.4rem;
+}
+
+.risk.success {
+  border-color: rgba(34, 197, 94, 0.9);
+  background: rgba(34, 197, 94, 0.2);
+}

--- a/tests/audit-core.test.js
+++ b/tests/audit-core.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { computeAuditScore, buildActionPlan } = require('../audit-core');
+
+test('computeAuditScore returns high score for mature org', () => {
+  const score = computeAuditScore({
+    charteIA: 'oui',
+    referentIA: 'oui',
+    cadreRGPD: 'oui',
+    validationJuridique: 'oui',
+    nbCasUsage: 5,
+    shadowPersonalAccounts: 'non',
+    formationIA: 'oui',
+    promptFramework: 'oui',
+    kpiIA: 'oui',
+    roadmapIA: 'oui',
+  });
+
+  assert.equal(score.total, 100);
+  assert.equal(score.level.label.includes('Piloté'), true);
+});
+
+test('computeAuditScore low score generates priorities', () => {
+  const score = computeAuditScore({
+    charteIA: 'non',
+    referentIA: 'non',
+    cadreRGPD: 'non',
+    validationJuridique: 'non',
+    nbCasUsage: 0,
+    shadowPersonalAccounts: 'oui',
+    formationIA: 'non',
+    promptFramework: 'non',
+    kpiIA: 'non',
+    roadmapIA: 'non',
+  });
+
+  assert.ok(score.total < 30);
+  const actions = buildActionPlan(score);
+  assert.ok(actions.length >= 4);
+});

--- a/tests/roi-core.test.js
+++ b/tests/roi-core.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  normalizeSector,
+  parseFrequency,
+  resolveHourlyCost,
+  computeRoi,
+} = require('../roi-core');
+
+test('normalizeSector maps expected French sectors', () => {
+  assert.equal(normalizeSector('École privée'), 'education');
+  assert.equal(normalizeSector('PME industrielle'), 'industrie');
+  assert.equal(normalizeSector('TPE services'), 'pme');
+  assert.equal(normalizeSector('Association'), 'default');
+});
+
+test('parseFrequency supports monthly and weekly input', () => {
+  assert.equal(parseFrequency('8/mois'), 8);
+  assert.equal(parseFrequency('2/semaine'), 8.66);
+  assert.equal(parseFrequency('abc'), 0);
+});
+
+test('resolveHourlyCost uses fallback when needed', () => {
+  const provided = resolveHourlyCost('45', 'PME');
+  assert.equal(provided.cost, 45);
+  assert.equal(provided.fallbackUsed, false);
+
+  const fallback = resolveHourlyCost('refus', 'école');
+  assert.equal(fallback.cost, 26);
+  assert.equal(fallback.fallbackUsed, true);
+});
+
+test('computeRoi returns coherent outputs', () => {
+  const roi = computeRoi({ tempsH: 5, volumeMensuel: 10, coutHoraire: 30 });
+  assert.equal(roi.tempsIA, 1);
+  assert.equal(roi.gainHMois, 40);
+  assert.equal(roi.gainEurosAn, 14400);
+  assert.equal(roi.roiNet, 12900);
+  assert.ok(roi.payback > 1 && roi.payback < 2);
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createServer, safePathFromUrl, buildHeaders } = require('../server');
+
+test('safePathFromUrl blocks directory traversal', () => {
+  assert.equal(safePathFromUrl('/../../etc/passwd'), null);
+});
+
+test('buildHeaders applies security and cache headers', () => {
+  const headers = buildHeaders('.js');
+  assert.equal(headers['x-content-type-options'], 'nosniff');
+  assert.equal(headers['x-frame-options'], 'DENY');
+  assert.match(headers['content-security-policy'], /default-src 'self'/);
+  assert.equal(headers['cache-control'], 'public, max-age=3600, immutable');
+});
+
+test('server responds to healthz and handles method restrictions', async () => {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const base = `http://127.0.0.1:${address.port}`;
+
+  const health = await fetch(`${base}/healthz`);
+  assert.equal(health.status, 200);
+  const payload = await health.json();
+  assert.equal(payload.status, 'ok');
+
+  const badMethod = await fetch(`${base}/`, { method: 'POST' });
+  assert.equal(badMethod.status, 405);
+
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+});


### PR DESCRIPTION
### Motivation
- Replace the previous ROI-first diagnostic with an audit-centric flow that evaluates IA maturity and produces a concrete 30/60/90 action plan.
- Centralize scoring/business logic so the audit engine is reusable and testable outside the UI.
- Provide an interactive, reproducible demo and simple exports to validate results and share reports.

### Description
- Added `audit-core.js` implementing `computeAuditScore(session)` and `buildActionPlan(score)` using a 100-point model across five pillars (gouvernance, conformité, usages, compétences, pilotage).
- Reworked UI flow and report by adding `index.html` and `app.js` to collect audit answers and render `scoreCard`, per-pillar cards, `riskBadges`, prioritized action plan, and JSON/CSV exports.
- Updated styling in `styles.css` and retained the existing `roi-core.js` (ROI helpers) for backward compatibility and regression safety.
- Added unit tests `tests/audit-core.test.js`, kept `tests/roi-core.test.js`, and updated `README.md` with running, testing and demo instructions.

### Testing
- Static checks `node --check app.js` and `node --check audit-core.js` completed successfully.
- Unit tests `node --test tests/audit-core.test.js` (2 tests) and `node --test tests/roi-core.test.js` (4 tests) passed without failures.
- Launched a local server with `python3 -m http.server 4173` and ran a scripted Playwright demo which exercised the full questionnaire and produced the screenshot `artifacts/audit-ia-demo.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1bcbe1c08323aefb437cb0bc08fd)